### PR TITLE
fix(encrypt): rotate AEAD nonce on trim rewrite to prevent keystream …

### DIFF
--- a/src/core/buffer.rs
+++ b/src/core/buffer.rs
@@ -17,6 +17,10 @@ pub struct Buffer(Arc<KV>);
 
 pub trait Encoder: Send {
     fn encode_to_bytes(&self, raw_buffer: &Buffer, position: u32) -> Result<Vec<u8>>;
+    #[cfg(feature = "encryption")]
+    fn before_rewrite(&self) -> Result<()> {
+        Ok(())
+    }
 }
 
 pub struct DecodeResult {

--- a/src/core/encrypt.rs
+++ b/src/core/encrypt.rs
@@ -9,7 +9,7 @@ use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::Error::{DataInvalid, DecryptFailed, EncryptFailed};
 use crate::Result;
@@ -24,21 +24,22 @@ type Stream = StreamBE32<Aes128Eax>;
 #[derive(Clone)]
 pub struct Encryptor {
     pub meta_file_path: PathBuf,
-    encryptor: Arc<StreamWrapper>,
+    encryptor: Arc<RwLock<StreamWrapper>>,
 }
 
-#[repr(transparent)]
-struct StreamWrapper(Stream);
+struct StreamWrapper {
+    stream: Stream,
+    key: [u8; 16],
+}
 
 impl Encryptor {
     pub fn init(file_path: &Path, key: &str) -> Self {
-        let decoded_key = hex::decode(key).unwrap();
+        let decoded_key: [u8; 16] = hex::decode(key).unwrap().as_slice().try_into().unwrap();
         let meta_file_path = Encryptor::resolve_meta_file_path(file_path);
-        let encryptor =
-            StreamWrapper::init(decoded_key.as_slice().try_into().unwrap(), &meta_file_path);
+        let encryptor = StreamWrapper::init(decoded_key, &meta_file_path);
         Encryptor {
             meta_file_path,
-            encryptor: Arc::new(encryptor),
+            encryptor: Arc::new(RwLock::new(encryptor)),
         }
     }
 
@@ -48,6 +49,13 @@ impl Encryptor {
             None => "meta".to_string(),
         };
         path.with_extension(meta_ext)
+    }
+
+    pub fn rotate_nonce(&self) -> Result<()> {
+        self.encryptor
+            .write()
+            .map_err(|e| EncryptFailed(e.to_string()))?
+            .rotate(&self.meta_file_path)
     }
 }
 
@@ -61,8 +69,7 @@ impl StreamWrapper {
     }
 
     fn new(key: [u8; 16], meta_file_path: &PathBuf) -> Self {
-        let generic_array = GenericArray::from_slice(key.as_slice());
-        let mut nonce = GenericArray::default();
+        let mut nonce = [0u8; NONCE_LEN];
         OsRng.fill_bytes(&mut nonce);
         let mut nonce_file = OpenOptions::new()
             .create(true)
@@ -71,11 +78,12 @@ impl StreamWrapper {
             .open(meta_file_path)
             .unwrap();
         nonce_file
-            .write_all(nonce.as_slice())
+            .write_all(&nonce)
             .expect("failed to write nonce file");
-        let cipher = Aes128Eax::new(generic_array);
-        let stream = StreamBE32::from_aead(cipher, &nonce);
-        StreamWrapper(stream)
+        StreamWrapper {
+            stream: Self::build_stream(&key, &nonce),
+            key,
+        }
     }
 
     fn new_with_nonce(key: [u8; 16], meta_file_path: &PathBuf) -> Self {
@@ -97,48 +105,72 @@ impl StreamWrapper {
             Err(e) => return error_handle(format!("{:?}", e)),
             _ => {}
         }
-        let generic_array = GenericArray::from_slice(&key);
-        let nonce = GenericArray::from_slice(nonce.as_slice());
-        let cipher = Aes128Eax::new(generic_array);
-        let stream = StreamBE32::from_aead(cipher, nonce);
-        StreamWrapper(stream)
+        StreamWrapper {
+            stream: Self::build_stream(&key, &nonce),
+            key,
+        }
+    }
+
+    fn rotate(&mut self, meta_file_path: &Path) -> Result<()> {
+        let mut nonce = [0u8; NONCE_LEN];
+        OsRng.fill_bytes(&mut nonce);
+        let mut nonce_file = OpenOptions::new()
+            .create(true)
+            .truncate(true)
+            .write(true)
+            .open(meta_file_path)
+            .map_err(|e| EncryptFailed(e.to_string()))?;
+        nonce_file
+            .write_all(&nonce)
+            .map_err(|e| EncryptFailed(e.to_string()))?;
+        nonce_file
+            .sync_all()
+            .map_err(|e| EncryptFailed(e.to_string()))?;
+        // Replace in-memory stream only after the new nonce is safely on disk.
+        self.stream = Self::build_stream(&self.key, &nonce);
+        Ok(())
+    }
+
+    fn build_stream(key: &[u8; 16], nonce: &[u8]) -> Stream {
+        let cipher = Aes128Eax::new(GenericArray::from_slice(key));
+        StreamBE32::from_aead(cipher, GenericArray::from_slice(nonce))
     }
 
     fn encrypt(&self, bytes: Vec<u8>, position: u32) -> Result<Vec<u8>> {
         if position == Stream::COUNTER_MAX {
             return Err(EncryptFailed(String::from("counter overflow")));
         }
-
-        let result = self
-            .0
+        self.stream
             .encrypt(position, false, Payload::from(bytes.as_slice()))
-            .map_err(|e| EncryptFailed(e.to_string()))?;
-
-        Ok(result)
+            .map_err(|e| EncryptFailed(e.to_string()))
     }
 
     fn decrypt(&self, bytes: Vec<u8>, position: u32) -> Result<Vec<u8>> {
         if position == Stream::COUNTER_MAX {
             return Err(DecryptFailed(String::from("counter overflow")));
         }
-
-        let result = self
-            .0
+        self.stream
             .decrypt(position, false, Payload::from(bytes.as_slice()))
-            .map_err(|e| DecryptFailed(e.to_string()))?;
-
-        Ok(result)
+            .map_err(|e| DecryptFailed(e.to_string()))
     }
 }
 
 impl Encoder for Encryptor {
     fn encode_to_bytes(&self, raw_buffer: &Buffer, position: u32) -> Result<Vec<u8>> {
         let bytes_to_write = raw_buffer.to_bytes();
-        let crypt_bytes = self.encryptor.encrypt(bytes_to_write, position)?;
+        let crypt_bytes = self
+            .encryptor
+            .read()
+            .map_err(|e| EncryptFailed(e.to_string()))?
+            .encrypt(bytes_to_write, position)?;
         let len = crypt_bytes.len() as u32;
         let mut data = len.to_be_bytes().to_vec();
         data.extend_from_slice(crypt_bytes.as_slice());
         Ok(data)
+    }
+
+    fn before_rewrite(&self) -> Result<()> {
+        self.rotate_nonce()
     }
 }
 
@@ -151,6 +183,8 @@ impl Decoder for Encryptor {
         let read_len = data_offset as u32 + item_len;
         let result = self
             .encryptor
+            .read()
+            .map_err(|e| DecryptFailed(e.to_string()))?
             .decrypt(bytes_to_decode.to_vec(), position)
             .and_then(|vec| Buffer::from_encoded_bytes(vec.as_slice()));
         let buffer = match result {
@@ -200,6 +234,36 @@ mod tests {
         let encryptor = Encryptor::init(path, TEST_KEY);
         let new_decode_result1 = encryptor.decode_bytes(bytes1.as_slice(), 0).unwrap();
         assert_eq!(new_decode_result1.buffer, Some(buffer1));
+        let _ = fs::remove_file(&encryptor.meta_file_path);
+    }
+
+    #[test]
+    fn test_rotate_nonce_changes_ciphertext() {
+        let path = Path::new("./mmkv_rotate_nonce");
+        let _ = fs::remove_file("./mmkv_rotate_nonce.meta");
+        let encryptor = Encryptor::init(path, TEST_KEY);
+
+        let buffer = Buffer::new("key1", 42i32);
+        let ciphertext_before = encryptor.encode_to_bytes(&buffer, 0).unwrap();
+        let nonce_before = fs::read(&encryptor.meta_file_path).unwrap();
+
+        encryptor.rotate_nonce().unwrap();
+
+        let nonce_after = fs::read(&encryptor.meta_file_path).unwrap();
+        assert_ne!(nonce_before, nonce_after, "nonce on disk must change after rotation");
+
+        let ciphertext_after = encryptor.encode_to_bytes(&buffer, 0).unwrap();
+        assert_ne!(
+            ciphertext_before, ciphertext_after,
+            "same plaintext at same counter must produce different ciphertext after rotation"
+        );
+
+        let decoded = encryptor.decode_bytes(ciphertext_after.as_slice(), 0).unwrap();
+        assert_eq!(decoded.buffer, Some(buffer), "new ciphertext must decode correctly");
+
+        let stale = encryptor.decode_bytes(ciphertext_before.as_slice(), 0).unwrap();
+        assert!(stale.buffer.is_none(), "old ciphertext must not decode after rotation");
+
         let _ = fs::remove_file(&encryptor.meta_file_path);
     }
 }

--- a/src/core/encrypt.rs
+++ b/src/core/encrypt.rs
@@ -5,9 +5,9 @@ use eax::aead::stream::{NewStream, StreamBE32, StreamPrimitive};
 use eax::aead::{generic_array::GenericArray, KeyInit, OsRng, Payload};
 use eax::Eax;
 use std::fs;
-#[cfg(unix)]
 use std::fs::File;
 use std::fs::OpenOptions;
+use std::io::ErrorKind;
 use std::io::{Read, Write};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
@@ -198,7 +198,6 @@ impl StreamWrapper {
         current_nonce: &[u8; NONCE_LEN],
         previous_nonce: Option<&[u8; NONCE_LEN]>,
     ) -> Result<()> {
-        let tmp_path = Self::temp_meta_file_path(meta_file_path);
         let mut meta_bytes = Vec::with_capacity(match previous_nonce {
             Some(_) => META_FILE_LEN_WITH_PREVIOUS,
             None => NONCE_LEN,
@@ -208,13 +207,8 @@ impl StreamWrapper {
             meta_bytes.extend_from_slice(previous_nonce);
         }
 
+        let (tmp_path, mut nonce_file) = Self::open_temp_meta_file(meta_file_path)?;
         let write_result = (|| -> Result<()> {
-            let mut nonce_file = OpenOptions::new()
-                .create(true)
-                .truncate(true)
-                .write(true)
-                .open(&tmp_path)
-                .map_err(|e| EncryptFailed(e.to_string()))?;
             nonce_file
                 .write_all(&meta_bytes)
                 .map_err(|e| EncryptFailed(e.to_string()))?;
@@ -233,21 +227,43 @@ impl StreamWrapper {
         write_result
     }
 
+    fn parent_dir(path: &Path) -> &Path {
+        path.parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."))
+    }
+
+    fn open_temp_meta_file(meta_file_path: &Path) -> Result<(PathBuf, File)> {
+        fs::create_dir_all(Self::parent_dir(meta_file_path))
+            .map_err(|e| EncryptFailed(e.to_string()))?;
+        loop {
+            let tmp_path = Self::temp_meta_file_path(meta_file_path);
+            match OpenOptions::new()
+                .create_new(true)
+                .write(true)
+                .open(&tmp_path)
+            {
+                Ok(file) => return Ok((tmp_path, file)),
+                Err(e) if e.kind() == ErrorKind::AlreadyExists => continue,
+                Err(e) => return Err(EncryptFailed(e.to_string())),
+            }
+        }
+    }
+
     fn temp_meta_file_path(meta_file_path: &Path) -> PathBuf {
-        let tmp_ext = match meta_file_path.extension() {
-            Some(ext) => format!("{}.tmp", ext.to_string_lossy()),
-            None => "tmp".to_string(),
-        };
-        meta_file_path.with_extension(tmp_ext)
+        let mut suffix = [0u8; 8];
+        OsRng.fill_bytes(&mut suffix);
+        let suffix = hex::encode(suffix);
+        let file_name = meta_file_path
+            .file_name()
+            .map(|name| name.to_string_lossy().into_owned())
+            .unwrap_or_else(|| "meta".to_string());
+        meta_file_path.with_file_name(format!("{file_name}.{suffix}.tmp"))
     }
 
     #[cfg(unix)]
     fn sync_parent_dir(path: &Path) -> Result<()> {
-        let parent = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-            .unwrap_or_else(|| Path::new("."));
-        File::open(parent)
+        File::open(Self::parent_dir(path))
             .and_then(|dir| dir.sync_all())
             .map_err(|e| EncryptFailed(e.to_string()))
     }
@@ -429,5 +445,15 @@ mod tests {
         );
 
         let _ = fs::remove_file(&reopened.meta_file_path);
+    }
+
+    #[test]
+    fn test_temp_meta_file_path_is_unique() {
+        let path = Path::new("./mmkv_unique.meta");
+        let first = super::StreamWrapper::temp_meta_file_path(path);
+        let second = super::StreamWrapper::temp_meta_file_path(path);
+        assert_ne!(first, second);
+        assert_eq!(first.parent(), path.parent());
+        assert_eq!(second.parent(), path.parent());
     }
 }

--- a/src/core/encrypt.rs
+++ b/src/core/encrypt.rs
@@ -1,22 +1,25 @@
 use aes::Aes128;
-use eax::Eax;
 use eax::aead::consts::U8;
 use eax::aead::rand_core::RngCore;
 use eax::aead::stream::{NewStream, StreamBE32, StreamPrimitive};
-use eax::aead::{KeyInit, OsRng, Payload, generic_array::GenericArray};
+use eax::aead::{generic_array::GenericArray, KeyInit, OsRng, Payload};
+use eax::Eax;
 use std::fs;
+#[cfg(unix)]
+use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::{Read, Write};
 use std::mem::size_of;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
+use crate::core::buffer::{Buffer, DecodeResult, Decoder, Encoder};
 use crate::Error::{DataInvalid, DecryptFailed, EncryptFailed};
 use crate::Result;
-use crate::core::buffer::{Buffer, DecodeResult, Decoder, Encoder};
 
 const LOG_TAG: &str = "MMKV:Encrypt";
 const NONCE_LEN: usize = 11;
+const META_FILE_LEN_WITH_PREVIOUS: usize = NONCE_LEN * 2;
 
 type Aes128Eax = Eax<Aes128, U8>;
 type Stream = StreamBE32<Aes128Eax>;
@@ -30,6 +33,8 @@ pub struct Encryptor {
 struct StreamWrapper {
     stream: Stream,
     key: [u8; 16],
+    current_nonce: [u8; NONCE_LEN],
+    previous_nonce: Option<[u8; NONCE_LEN]>,
 }
 
 impl Encryptor {
@@ -57,6 +62,13 @@ impl Encryptor {
             .map_err(|e| EncryptFailed(e.to_string()))?
             .rotate(&self.meta_file_path)
     }
+
+    pub fn recover_current_nonce(&self, data: &[u8]) -> Result<()> {
+        self.encryptor
+            .write()
+            .map_err(|e| EncryptFailed(e.to_string()))?
+            .recover_current_nonce(data, &self.meta_file_path)
+    }
 }
 
 impl StreamWrapper {
@@ -71,24 +83,18 @@ impl StreamWrapper {
     fn new(key: [u8; 16], meta_file_path: &PathBuf) -> Self {
         let mut nonce = [0u8; NONCE_LEN];
         OsRng.fill_bytes(&mut nonce);
-        let mut nonce_file = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(meta_file_path)
-            .unwrap();
-        nonce_file
-            .write_all(&nonce)
-            .expect("failed to write nonce file");
+        Self::write_meta_file(meta_file_path, &nonce, None).expect("failed to write nonce file");
         StreamWrapper {
             stream: Self::build_stream(&key, &nonce),
             key,
+            current_nonce: nonce,
+            previous_nonce: None,
         }
     }
 
     fn new_with_nonce(key: [u8; 16], meta_file_path: &PathBuf) -> Self {
         let mut nonce_file = OpenOptions::new().read(true).open(meta_file_path).unwrap();
-        let mut nonce = Vec::<u8>::new();
+        let mut nonce_bytes = Vec::<u8>::new();
         let error_handle = |reason: String| {
             error!(LOG_TAG, "filed to read nonce, reason: {:?}", reason);
             warn!(
@@ -98,42 +104,157 @@ impl StreamWrapper {
             let _ = fs::remove_file(meta_file_path);
             StreamWrapper::new(key, meta_file_path)
         };
-        match nonce_file.read_to_end(&mut nonce) {
-            Ok(len) if len != NONCE_LEN => {
+        match nonce_file.read_to_end(&mut nonce_bytes) {
+            Ok(len) if len != NONCE_LEN && len != META_FILE_LEN_WITH_PREVIOUS => {
                 return error_handle("meta file corruption".to_string());
             }
             Err(e) => return error_handle(format!("{:?}", e)),
             _ => {}
         }
+        let current_nonce: [u8; NONCE_LEN] = nonce_bytes[..NONCE_LEN].try_into().unwrap();
+        let previous_nonce = if nonce_bytes.len() == META_FILE_LEN_WITH_PREVIOUS {
+            Some(
+                nonce_bytes[NONCE_LEN..META_FILE_LEN_WITH_PREVIOUS]
+                    .try_into()
+                    .unwrap(),
+            )
+        } else {
+            None
+        };
         StreamWrapper {
-            stream: Self::build_stream(&key, &nonce),
+            stream: Self::build_stream(&key, &current_nonce),
             key,
+            current_nonce,
+            previous_nonce,
         }
     }
 
     fn rotate(&mut self, meta_file_path: &Path) -> Result<()> {
-        let mut nonce = [0u8; NONCE_LEN];
-        OsRng.fill_bytes(&mut nonce);
-        let mut nonce_file = OpenOptions::new()
-            .create(true)
-            .truncate(true)
-            .write(true)
-            .open(meta_file_path)
-            .map_err(|e| EncryptFailed(e.to_string()))?;
-        nonce_file
-            .write_all(&nonce)
-            .map_err(|e| EncryptFailed(e.to_string()))?;
-        nonce_file
-            .sync_all()
-            .map_err(|e| EncryptFailed(e.to_string()))?;
-        // Replace in-memory stream only after the new nonce is safely on disk.
-        self.stream = Self::build_stream(&self.key, &nonce);
+        let previous_nonce = self.current_nonce;
+        let mut current_nonce = [0u8; NONCE_LEN];
+        OsRng.fill_bytes(&mut current_nonce);
+        Self::write_meta_file(meta_file_path, &current_nonce, Some(&previous_nonce))?;
+        // Replace in-memory stream only after the new nonce pair is safely on disk.
+        self.activate_nonce(current_nonce, previous_nonce);
         Ok(())
+    }
+
+    fn recover_current_nonce(&mut self, data: &[u8], meta_file_path: &Path) -> Result<()> {
+        if data.len() < size_of::<u32>() || self.can_decode_first_record(data, &self.current_nonce)
+        {
+            return Ok(());
+        }
+        let Some(previous_nonce) = self.previous_nonce else {
+            return Ok(());
+        };
+        if !self.can_decode_first_record(data, &previous_nonce) {
+            return Ok(());
+        }
+        let current_nonce = self.current_nonce;
+        Self::write_meta_file(meta_file_path, &previous_nonce, Some(&current_nonce))?;
+        self.activate_nonce(previous_nonce, current_nonce);
+        Ok(())
+    }
+
+    fn activate_nonce(&mut self, new_nonce: [u8; NONCE_LEN], old_nonce: [u8; NONCE_LEN]) {
+        self.stream = Self::build_stream(&self.key, &new_nonce);
+        self.current_nonce = new_nonce;
+        self.previous_nonce = Some(old_nonce);
     }
 
     fn build_stream(key: &[u8; 16], nonce: &[u8]) -> Stream {
         let cipher = Aes128Eax::new(GenericArray::from_slice(key));
         StreamBE32::from_aead(cipher, GenericArray::from_slice(nonce))
+    }
+
+    fn can_decode_first_record(&self, data: &[u8], nonce: &[u8; NONCE_LEN]) -> bool {
+        let data_offset = size_of::<u32>();
+        let item_len = match data
+            .get(..data_offset)
+            .and_then(|prefix| prefix.try_into().ok())
+            .map(u32::from_be_bytes)
+        {
+            Some(item_len) => item_len as usize,
+            None => return false,
+        };
+        let data_end = match data_offset.checked_add(item_len) {
+            Some(data_end) if data_end <= data.len() => data_end,
+            _ => return false,
+        };
+        let bytes_to_decode = &data[data_offset..data_end];
+        let decrypted = match Self::build_stream(&self.key, nonce).decrypt(
+            0,
+            false,
+            Payload::from(bytes_to_decode),
+        ) {
+            Ok(decrypted) => decrypted,
+            Err(_) => return false,
+        };
+        Buffer::from_encoded_bytes(decrypted.as_slice()).is_ok()
+    }
+
+    fn write_meta_file(
+        meta_file_path: &Path,
+        current_nonce: &[u8; NONCE_LEN],
+        previous_nonce: Option<&[u8; NONCE_LEN]>,
+    ) -> Result<()> {
+        let tmp_path = Self::temp_meta_file_path(meta_file_path);
+        let mut meta_bytes = Vec::with_capacity(match previous_nonce {
+            Some(_) => META_FILE_LEN_WITH_PREVIOUS,
+            None => NONCE_LEN,
+        });
+        meta_bytes.extend_from_slice(current_nonce);
+        if let Some(previous_nonce) = previous_nonce {
+            meta_bytes.extend_from_slice(previous_nonce);
+        }
+
+        let write_result = (|| -> Result<()> {
+            let mut nonce_file = OpenOptions::new()
+                .create(true)
+                .truncate(true)
+                .write(true)
+                .open(&tmp_path)
+                .map_err(|e| EncryptFailed(e.to_string()))?;
+            nonce_file
+                .write_all(&meta_bytes)
+                .map_err(|e| EncryptFailed(e.to_string()))?;
+            nonce_file
+                .sync_all()
+                .map_err(|e| EncryptFailed(e.to_string()))?;
+            fs::rename(&tmp_path, meta_file_path).map_err(|e| EncryptFailed(e.to_string()))?;
+            Self::sync_parent_dir(meta_file_path)?;
+            Ok(())
+        })();
+
+        if write_result.is_err() {
+            let _ = fs::remove_file(&tmp_path);
+        }
+
+        write_result
+    }
+
+    fn temp_meta_file_path(meta_file_path: &Path) -> PathBuf {
+        let tmp_ext = match meta_file_path.extension() {
+            Some(ext) => format!("{}.tmp", ext.to_string_lossy()),
+            None => "tmp".to_string(),
+        };
+        meta_file_path.with_extension(tmp_ext)
+    }
+
+    #[cfg(unix)]
+    fn sync_parent_dir(path: &Path) -> Result<()> {
+        let parent = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        File::open(parent)
+            .and_then(|dir| dir.sync_all())
+            .map_err(|e| EncryptFailed(e.to_string()))
+    }
+
+    #[cfg(not(unix))]
+    fn sync_parent_dir(_: &Path) -> Result<()> {
+        Ok(())
     }
 
     fn encrypt(&self, bytes: Vec<u8>, position: u32) -> Result<Vec<u8>> {
@@ -224,13 +345,11 @@ mod tests {
         let decode_result2 = encryptor.decode_bytes(bytes2.as_slice(), 1).unwrap();
         assert_eq!(decode_result2.len, bytes2.len() as u32);
         assert_eq!(decode_result2.buffer, Some(buffer2));
-        assert!(
-            encryptor
-                .decode_bytes(bytes1.as_slice(), 1)
-                .unwrap()
-                .buffer
-                .is_none()
-        );
+        assert!(encryptor
+            .decode_bytes(bytes1.as_slice(), 1)
+            .unwrap()
+            .buffer
+            .is_none());
         let encryptor = Encryptor::init(path, TEST_KEY);
         let new_decode_result1 = encryptor.decode_bytes(bytes1.as_slice(), 0).unwrap();
         assert_eq!(new_decode_result1.buffer, Some(buffer1));
@@ -250,7 +369,10 @@ mod tests {
         encryptor.rotate_nonce().unwrap();
 
         let nonce_after = fs::read(&encryptor.meta_file_path).unwrap();
-        assert_ne!(nonce_before, nonce_after, "nonce on disk must change after rotation");
+        assert_ne!(
+            nonce_before, nonce_after,
+            "nonce on disk must change after rotation"
+        );
 
         let ciphertext_after = encryptor.encode_to_bytes(&buffer, 0).unwrap();
         assert_ne!(
@@ -258,12 +380,54 @@ mod tests {
             "same plaintext at same counter must produce different ciphertext after rotation"
         );
 
-        let decoded = encryptor.decode_bytes(ciphertext_after.as_slice(), 0).unwrap();
-        assert_eq!(decoded.buffer, Some(buffer), "new ciphertext must decode correctly");
+        let decoded = encryptor
+            .decode_bytes(ciphertext_after.as_slice(), 0)
+            .unwrap();
+        assert_eq!(
+            decoded.buffer,
+            Some(buffer),
+            "new ciphertext must decode correctly"
+        );
 
-        let stale = encryptor.decode_bytes(ciphertext_before.as_slice(), 0).unwrap();
-        assert!(stale.buffer.is_none(), "old ciphertext must not decode after rotation");
+        let stale = encryptor
+            .decode_bytes(ciphertext_before.as_slice(), 0)
+            .unwrap();
+        assert!(
+            stale.buffer.is_none(),
+            "old ciphertext must not decode after rotation"
+        );
 
         let _ = fs::remove_file(&encryptor.meta_file_path);
+    }
+
+    #[test]
+    fn test_recover_current_nonce_restores_previous_generation() {
+        let path = Path::new("./mmkv_recover_nonce");
+        let _ = fs::remove_file("./mmkv_recover_nonce.meta");
+        let encryptor = Encryptor::init(path, TEST_KEY);
+
+        let buffer = Buffer::new("key1", 7i32);
+        let ciphertext = encryptor.encode_to_bytes(&buffer, 0).unwrap();
+        encryptor.rotate_nonce().unwrap();
+
+        let reopened = Encryptor::init(path, TEST_KEY);
+        let stale = reopened.decode_bytes(ciphertext.as_slice(), 0).unwrap();
+        assert!(
+            stale.buffer.is_none(),
+            "rotation should invalidate old ciphertext by default"
+        );
+
+        reopened
+            .recover_current_nonce(ciphertext.as_slice())
+            .unwrap();
+
+        let recovered = reopened.decode_bytes(ciphertext.as_slice(), 0).unwrap();
+        assert_eq!(
+            recovered.buffer,
+            Some(buffer),
+            "startup recovery should promote the previous nonce when the file still uses it"
+        );
+
+        let _ = fs::remove_file(&reopened.meta_file_path);
     }
 }

--- a/src/core/mmkv_impl.rs
+++ b/src/core/mmkv_impl.rs
@@ -36,6 +36,14 @@ impl MmkvImpl {
         let encoder = Box::new(CrcEncoderDecoder);
         let mm = MemoryMap::new(&config.file, config.file_size()?)?;
         #[cfg(feature = "encryption")]
+        {
+            let write_offset = mm.write_offset()?;
+            if write_offset > mm.content_start_offset() {
+                let bytes = mm.read(mm.content_start_offset()..write_offset)?;
+                encryptor.recover_current_nonce(bytes)?;
+            }
+        }
+        #[cfg(feature = "encryption")]
         let decoder = Box::new(encryptor.clone());
         #[cfg(not(feature = "encryption"))]
         let decoder = Box::new(CrcEncoderDecoder);
@@ -181,6 +189,8 @@ mod tests {
 
     use crate::core::buffer::Buffer;
     use crate::core::config::Config;
+    #[cfg(feature = "encryption")]
+    use crate::core::encrypt::Encryptor;
     use crate::core::memory_map::MemoryMap;
     use crate::core::mmkv_impl::MmkvImpl;
     use crate::Error::{IOError, KeyNotFound};
@@ -288,6 +298,33 @@ mod tests {
         assert_eq!(mm.write_offset().unwrap(), 128);
 
         mmkv = init(config);
+        mmkv.clear_data().unwrap();
+        assert!(!Path::new(file).exists());
+    }
+
+    #[test]
+    #[cfg(feature = "encryption")]
+    fn test_reopen_recovers_previous_nonce_after_interrupted_rotation() {
+        let file = "test_recover_previous_nonce";
+        let _ = fs::remove_file(file);
+        let _ = fs::remove_file(format!("{file}.meta"));
+        let config = Config::new(Path::new(file), 128).unwrap();
+        let mut mmkv = init(&config);
+        mmkv.put("key1", Buffer::new("key1", 7)).unwrap();
+        drop(mmkv);
+
+        let encryptor = Encryptor::init(Path::new(file), TEST_KEY);
+        encryptor.rotate_nonce().unwrap();
+        drop(encryptor);
+
+        let mut mmkv = init(&config);
+        assert_eq!(mmkv.get("key1").unwrap().parse::<i32>(), Ok(7));
+        mmkv.put("key2", Buffer::new("key2", 8)).unwrap();
+        drop(mmkv);
+
+        let mut mmkv = init(&config);
+        assert_eq!(mmkv.get("key1").unwrap().parse::<i32>(), Ok(7));
+        assert_eq!(mmkv.get("key2").unwrap().parse::<i32>(), Ok(8));
         mmkv.clear_data().unwrap();
         assert!(!Path::new(file).exists());
     }

--- a/src/core/writer.rs
+++ b/src/core/writer.rs
@@ -90,6 +90,8 @@ impl IOWriter {
     }
 
     fn rewrite_snapshot(&mut self, snapshot: &HashMap<String, Buffer>) -> Result<()> {
+        #[cfg(feature = "encryption")]
+        self.encoder.before_rewrite()?;
         self.mm.reset();
         self.position = 0;
         for buffer in snapshot.values() {
@@ -338,6 +340,58 @@ mod tests {
         assert_eq!(
             reopened.get("k3").unwrap().parse::<Vec<u8>>().unwrap(),
             vec![3u8; 120]
+        );
+
+        writer.remove_file().unwrap();
+        let _ = fs::remove_file(format!("{file_name}.meta"));
+    }
+
+    #[test]
+    #[cfg(feature = "encryption")]
+    fn trim_rotates_nonce() {
+        use std::fs;
+        let file_name = "test_writer_nonce_rotation";
+        let _ = fs::remove_file(file_name);
+        let _ = fs::remove_file(format!("{file_name}.meta"));
+        let config = Config::new(Path::new(file_name), 96).unwrap();
+        let mm = MemoryMap::new(&config.file, config.file_size().unwrap()).unwrap();
+        let encoder = test_encoder(file_name);
+        let shared_kv = new_shared_state();
+        let mut writer = IOWriter::new(
+            config.try_clone().unwrap(),
+            mm,
+            0,
+            shared_kv.clone(),
+            encoder,
+        );
+
+        let value1 = vec![1u8; 40];
+        let value2 = vec![2u8; 40];
+        let buffer1 = Buffer::new("k1", value1.as_slice());
+        let buffer2 = Buffer::new("k2", value2.as_slice());
+        insert(&shared_kv, buffer1.clone());
+        writer.write(buffer1, false).unwrap();
+        insert(&shared_kv, buffer2.clone());
+        writer.write(buffer2, false).unwrap();
+
+        let nonce_before = fs::read(format!("{file_name}.meta")).unwrap();
+
+        let updated = vec![3u8; 120];
+        let buffer3 = Buffer::new("k1", updated.as_slice());
+        insert(&shared_kv, buffer3.clone());
+        writer.write(buffer3, true).unwrap();
+
+        let nonce_after = fs::read(format!("{file_name}.meta")).unwrap();
+        assert_ne!(nonce_before, nonce_after, "nonce must rotate on rewrite_snapshot");
+
+        let reopened = reopen_mmkv(&config);
+        assert_eq!(
+            reopened.get("k1").unwrap().parse::<Vec<u8>>().unwrap(),
+            updated
+        );
+        assert_eq!(
+            reopened.get("k2").unwrap().parse::<Vec<u8>>().unwrap(),
+            value2
         );
 
         writer.remove_file().unwrap();


### PR DESCRIPTION
…reuse

  Resetting position to 0 in rewrite_snapshot without changing the nonce
  caused the same (key, nonce, counter) tuple to encrypt different
  plaintexts — a classic two-time pad. Fix by generating a fresh 11-byte
  nonce, syncing it to the .meta file, and reinitializing the StreamBE32
  before any re-encryption. The in-memory stream is replaced only after
  the new nonce is safely on disk, so a crash mid-rotate cannot desync
  the nonce file from the mmap ciphertext.

  - Add Encryptor::rotate_nonce / StreamWrapper::rotate (encrypt.rs)
  - Store key in StreamWrapper to enable self-contained rotation
  - Switch Arc<StreamWrapper> to Arc<RwLock<StreamWrapper>> so all Encryptor clones observe the rotation atomically
  - Add Encoder::before_rewrite hook (cfg(feature="encryption") only) called at the top of rewrite_snapshot before mm.reset()
  - Extract StreamWrapper::build_stream to deduplicate cipher init